### PR TITLE
News セクションの追加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,26 +18,42 @@
   margin-bottom: 30;
 }
 
+.news dl {
+  display: flex;
+  flex-wrap: wrap;
+  border-top: solid 1px #c8c8c8;
+}
+.news dt {
+  width: 20%;
+  padding: 15px;
+  border-bottom: solid 1px #c8c8c8;
+}
+.news dd {
+  width: 80%;
+  padding: 15px;
+  border-bottom: solid 1px #c8c8c8;
+}
+@media screen and (max-width: 600px) {
+  .news dl {
+    flex-direction: column;
+  }
+  .news dt {
+    width: 100%;
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+  .news dd {
+    width: 100%;
+    padding-top: 0;
+  }
+}
+
 footer {
   padding: 10px 20px;
   font-size: 0.5rem;
   color: #fff;
   text-align: center;
   background-color: #24292e;
-}
-
-.test {
-  color: #0075c2;
-}
-@media screen and (min-width: 400px) {
-  .test {
-    color: #ff0;
-  }
-}
-@media screen and (min-width: 1000px) {
-  .test {
-    color: #f00;
-  }
 }
 
 /*# sourceMappingURL=style.css.map */

--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
       rel="stylesheet"
       href="css/style.css"
     />
+    <link
+      rel="stylesheet"
+      href="css/header.css"
+    />
   </head>
 
   <header>
@@ -53,6 +57,24 @@
         テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
         テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
       </p>
+    </section>
+    <section
+      class="news section-container"
+      id="news"
+    >
+      <h2 class="section-title">News</h2>
+      <dl>
+        <dt>2020.XX.XX</dt>
+        <dd>デザイン雑誌「ＸＸＸＸＸＸ Vol.11』に掲載していただきました。</dd>
+        <dt>2020.XX.XX</dt>
+        <dd>デザイン雑誌「ＸＸＸＸＸＸ Vol.11』に掲載していただきました。</dd>
+        <dt>2020.XX.XX</dt>
+        <dd>デザイン雑誌「ＸＸＸＸＸＸ Vol.11』に掲載していただきました。</dd>
+        <dt>2020.XX.XX</dt>
+        <dd>デザイン雑誌「ＸＸＸＸＸＸ Vol.11』に掲載していただきました。</dd>
+        <dt>2020.XX.XX</dt>
+        <dd>デザイン雑誌「ＸＸＸＸＸＸ Vol.11』に掲載していただきました。</dd>
+      </dl>
     </section>
   </main>
   <footer>

--- a/sass/_breakpoint.scss
+++ b/sass/_breakpoint.scss
@@ -1,7 +1,7 @@
 // NOTE: 必要に応じて値は更新してください
 $breakpoints: (
-  'sm': 'screen and (min-width: 400px)',
-  'md': 'screen and (min-width: 768px)',
-  'lg': 'screen and (min-width: 1000px)',
-  'xl': 'screen and (min-width: 1200px)',
+  'sm': 'screen and (max-width: 400px)',
+  'md': 'screen and (max-width: 600px)',
+  'lg': 'screen and (max-width: 1000px)',
+  'xl': 'screen and (max-width: 1200px)',
 ) !default;

--- a/sass/_news.scss
+++ b/sass/_news.scss
@@ -1,0 +1,32 @@
+.news {
+  dl {
+    display: flex;
+    flex-wrap: wrap;
+    border-top: solid 1px #c8c8c8;
+  }
+  dt {
+    width: 20%;
+    padding: 15px;
+    border-bottom: solid 1px #c8c8c8;
+  }
+  dd {
+    width: 80%;
+    padding: 15px;
+    border-bottom: solid 1px #c8c8c8;
+  }
+
+  @include mq(md) {
+    dl {
+      flex-direction: column;
+    }
+    dt {
+      width: 100%;
+      padding-bottom: 0;
+      border-bottom: 0;
+    }
+    dd {
+      width: 100%;
+      padding-top: 0;
+    }
+  }
+}

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -4,17 +4,5 @@
 @import '_common';
 
 @import '_about';
-
+@import '_news';
 @import '_footer';
-
-.test {
-  color: #0075c2;
-
-  @include mq(sm) {
-    color: #ff0;
-  }
-
-  @include mq(lg) {
-    color: #f00;
-  }
-}


### PR DESCRIPTION
## 関連 issue

https://github.com/makimakiforest/convert-static-site-to-wordpress/issues/43

## 作業内容

- Newsセクションの追加（PC・SP）
- 不要な記述の削除

## スクリーンショット（変更前/変更後）

| PC             | SP             |
| -------------- | -------------- |
| ![スクリーンショット 2023-04-21 20 59 29](https://user-images.githubusercontent.com/63849460/233630640-a9d63514-93cd-492d-8d9c-479f2b7bfe70.png) | ![スクリーンショット 2023-04-21 20 59 37](https://user-images.githubusercontent.com/63849460/233630680-214e2f3e-0c2b-465f-bfb5-6ebe4e7209ca.png) |

## 確認事項

- [x] セルフコメントの追加

## レビュー・動作確認方法

1.
